### PR TITLE
add takePicture support on iOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8718,8 +8718,8 @@
       "from": "git+https://github.com/QuartermasterInc/react-native-image-resizer.git"
     },
     "react-native-inat-camera": {
-      "version": "git+https://github.com/inaturalist/react-native-inat-camera.git#6fab1470a57a4c4001d889328a26657abbe3b9da",
-      "from": "git+https://github.com/inaturalist/react-native-inat-camera.git#6fab1470a57a4c4001d889328a26657abbe3b9da"
+      "version": "github:inaturalist/react-native-inat-camera#3db03456e392a8002fc0e8f464a5978aad025095",
+      "from": "github:inaturalist/react-native-inat-camera"
     },
     "react-native-jwt-io": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-native-geocoder": "git+https://github.com/a-voityuk/react-native-geocoder.git",
     "react-native-gesture-handler": "^1.0.12",
     "react-native-image-resizer": "git+https://github.com/QuartermasterInc/react-native-image-resizer.git",
-    "react-native-inat-camera": "git+https://github.com/inaturalist/react-native-inat-camera.git#6fab1470a57a4c4001d889328a26657abbe3b9da",
+    "react-native-inat-camera": "github:inaturalist/react-native-inat-camera",
     "react-native-jwt-io": "^1.0.3",
     "react-native-languages": "^3.0.1",
     "react-native-linear-gradient": "^2.5.3",


### PR DESCRIPTION
note this requires 6fab1470a57a4c4001d889328a26657abbe3b9da of
react-native-inat-camera
this requirement is now baked into the PR with the "do npm import of inat-camera via git commit hash" commit.