### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Seek is an app built for iOS and Android.
 
 ## Setup
 
-1. Make sure you're running Node v10.0.0.
+1. Make sure you're running the latest version of Node v10.X.
 2. Install dependences with `npm install`
 3. If building for iOS, run `pod install` from within the `ios` directory.
 4. Run `npm start`
-5. Build locally to a device or simulator by running `react-native run-ios` or `react-native run-android`
-6. Go to `android/app/src/main/res/values` and rename `config.xml.example` to `config.xml` (and change its values to match your API keys)
-7. Rename `config.example.js` to `config.js` and change the JWT secret.
-8. Add AR Camera model files to the project. On Android, these files are named `optimized_model.tflite` and `taxonomy_data.csv`, and they should be placed in a camera folder within Android assets (i.e. `android/app/src/main/assets/camera`). On iOS, these files are named `optimized_model.mlmodel` and `taxonomy.json` and should be added to the Resources folder in XCode. 
-9. Add common names files to `Seek/utility/commonNames` to allow the AR camera to load common names in localized languages. These files are titled `commonNamesDict-0.js` to `commonNamesDict-9.js`.
+5. This project uses a macOS `security` tool to store keystore passwords. If building for Android on Windows or Linux, replace the implementation of `getPassword()` in `app/build.gradle` with a hardcoded string.
+6. Build locally to a device or simulator by running `react-native run-ios` or `react-native run-android`
+7. Go to `android/app/src/main/res/values` and rename `config.xml.example` to `config.xml` (and change its values to match your API keys)
+8. Rename `config.example.js` to `config.js` and change the JWT secret.
+9. Add AR Camera model files to the project. On Android, these files are named `optimized_model.tflite` and `taxonomy_data.csv`, and they should be placed in a camera folder within Android assets (i.e. `android/app/src/main/assets/camera`). On iOS, these files are named `optimized_model.mlmodel` and `taxonomy.json` and should be added to the Resources folder in XCode. 
+10. Add common names files to `Seek/utility/commonNames` to allow the AR camera to load common names in localized languages. These files are titled `commonNamesDict-0.js` to `commonNamesDict-9.js`.
 
 ## Manual Linking
 Most third-party libraries use autolinking as of [React Native 0.60.0](https://facebook.github.io/react-native/blog/2019/07/03/version-60#native-modules-are-now-autolinked). There is one exception, which is listed in the [react-native.config.js](https://github.com/inaturalist/SeekReactNative/blob/master/react-native.config.js) file. 


### PR DESCRIPTION
In the process of trying to build the app, I ran across a couple things. I originally assumed Node 10.0.0 was old since it's the very first release, so I went with Node 12 LTS, only to find that Realm didn't support it. Calling out the latest version of 10 seemed more secure to me. 

I suppose most developers will be using MacOS since it's required for building iOS, but I ran into the "security" command missing. It fails in a cryptic way too.