### PR TITLE
Reword "Species nearby" location requirement text

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -6,8 +6,8 @@
     "no_species": "Looks like there haven’t been many species observed nearby! Try changing your location or broadening the species filter.",
     "input_location_above_map": "No location found; input a location name above to load the map and search for species nearby",
     "error_alert_location_services": "To continue, turn on location services in your device settings",
-    "species_nearby_requires_location": "Species nearby requires your location. Please enable location in settings",
-    "species_nearby_requires_android_accuracy": "Species nearby requires your location. Please check that location services are enabled.",
+    "species_nearby_requires_location": "Viewing nearby species requires your location. Please enable location in settings",
+    "species_nearby_requires_android_accuracy": "Viewing nearby species requires your location. Please check that location services are enabled.",
     "choose_location_on_map": "CHOOSE LOCATION ON MAP"
   },
   "get_started": {


### PR DESCRIPTION
I felt like these lines were a bit clunky, especially when translated into Swedish, but also in the English source. I understand that it refers to the "Species nearby"-feature, but it still felt a bit off imo. Sorry if this feels nitpicky 😅

Other verb suggestions would be "seeing", "finding", or even "generating" to go in line with `species_nearby_internet_error`s "We need the Internet to generate nearby species.", although I think that one might also feel a bit weird to non-programmer users?

Also, sorry if this is not how you suggest changes to the text. I'm ~still at work~ definitely not at work and haven't had time to fully dig into the structure of the codebase yet.

Also also, sorry about the newline. Due to aforementioned reasons, I don't have access to my laptop and have to make due editing through GitHub.