### PR TITLE
Move token to password reset POST request's params instead of headers

### DIFF
--- a/components/Auth/Login/ForgotPasswordScreen.js
+++ b/components/Auth/Login/ForgotPasswordScreen.js
@@ -25,12 +25,11 @@ const ForgotPasswordScreen = ( ): Node => {
 
   const emailForgotPassword = ( ) => {
 
-    const params = { user: { email } };
+    const params = { user: { email }, authenticity_token: token };
 
     const headers = {
       "Content-Type": "application/json",
-      "User-Agent": createUserAgent( ),
-      "Authorization": token
+      "User-Agent": createUserAgent( )
     };
 
     const site = "https://www.inaturalist.org";

--- a/components/Auth/Login/ForgotPasswordScreen.js
+++ b/components/Auth/Login/ForgotPasswordScreen.js
@@ -25,7 +25,7 @@ const ForgotPasswordScreen = ( ): Node => {
 
   const emailForgotPassword = ( ) => {
 
-    const params = { user: { email }, authenticity_token: token };
+    const params = { user: { email } };
 
     const headers = {
       "Content-Type": "application/json",


### PR DESCRIPTION
This PR fixes the bug that the user does not retrieve an email after pressing on "Reset password".
https://github.com/inaturalist/SeekReactNative/issues/565