### PR TITLE
Fix state bug on initial camera roll load

### DIFF
--- a/components/Camera/Gallery/GalleryScreen.js
+++ b/components/Camera/Gallery/GalleryScreen.js
@@ -136,21 +136,6 @@ const GalleryScreen = (): Node => {
     }
   }, [photos.length, fetchPhotos] );
 
-  const initialFetch = useCallback( ( ) => {
-    // attempting to fix issue on some iOS devices where photos never appear
-    // assuming the above useEffect hook does not get called for some reason
-    const timer = setTimeout( ( ) => {
-      if ( photoCount.current === 0 ) {
-        fetchPhotos( );
-      }
-    }, 3000 );
-
-    if ( photoCount.current > 0 ) {
-      clearTimeout( timer );
-    }
-    return ( ) => clearTimeout( timer );
-  }, [fetchPhotos] );
-
   useEffect( ( ) => {
     const requestAndroidPermissions = async ( ) => {
       if ( Platform.OS === "android" ) {
@@ -164,12 +149,9 @@ const GalleryScreen = (): Node => {
     navigation.addListener( "focus", ( ) => {
       setObservation( null );
       requestAndroidPermissions( );
-      if ( Platform.OS === "ios" ) {
-        initialFetch( );
-      }
     } );
     navigation.addListener( "blur", ( ) => dispatch( { type: "RESET_LOADING" } ) );
-  }, [navigation, initialFetch, setObservation] );
+  }, [navigation, setObservation] );
 
   const renderImageList = ( ) => {
     if ( error ) {

--- a/components/Camera/Gallery/GalleryScreen.js
+++ b/components/Camera/Gallery/GalleryScreen.js
@@ -93,8 +93,9 @@ const GalleryScreen = (): Node => {
       // permission but has not given Seek access to a single photo
       dispatch( { type: "ERROR", error: "photos", errorEvent: null } );
     } else {
-      const uniquePhotos = checkForUniquePhotos( seen, data );
-      dispatch( { type: "APPEND_PHOTOS", photos: photos.concat( uniquePhotos ), pageInfo } );
+      const { uniqAssets, newSeen } = checkForUniquePhotos( seen, data );
+      const newPhotos = photos.concat( uniqAssets );
+      dispatch( { type: "APPEND_PHOTOS", photos: newPhotos, seen: newSeen, pageInfo } );
     }
   }, [photos, seen] );
 

--- a/components/Camera/Gallery/GalleryScreen.js
+++ b/components/Camera/Gallery/GalleryScreen.js
@@ -93,7 +93,7 @@ const GalleryScreen = (): Node => {
       // permission but has not given Seek access to a single photo
       dispatch( { type: "ERROR", error: "photos", errorEvent: null } );
     } else {
-      const { uniqAssets, newSeen } = checkForUniquePhotos( seen, data );
+      const { newSeen, uniqAssets } = checkForUniquePhotos( seen, data );
       const newPhotos = photos.concat( uniqAssets );
       dispatch( { type: "APPEND_PHOTOS", photos: newPhotos, seen: newSeen, pageInfo } );
     }

--- a/utility/cameraRollHelpers.js
+++ b/utility/cameraRollHelpers.js
@@ -32,18 +32,22 @@ const fetchGalleryPhotos = async ( album: ?string, lastCursor: ?string ): Promis
   return photos;
 };
 
-const checkForUniquePhotos = ( seen: Set<Object>, assets: Array<Object> ): Array<Object> => {
+const checkForUniquePhotos = ( seen: Set<Object>, assets: Array<Object> ): { assets: Array<Object>, newSeen: Set<Object> } => {
   // from cameraroll example: https://github.com/react-native-cameraroll/react-native-cameraroll/blob/7fa9b7c062c166cd94e62b4ab5d1f7b5f663c9a0/example/js/CameraRollView.js#L177
-  const uniqAssets = assets.map( asset => {
-    let value = asset.node.image.uri;
-    if ( seen.has( value ) ) {
-      return;
+  
+  // seen state can't be mutated locally, instead it's returned and 
+  // used by the parent component to update state
+  const newSeen = new Set( seen );
+
+  const uniqAssets = assets.filter( asset => {
+    const value = asset.node.image.uri;
+    if ( newSeen.has( value ) ) {
+      return false;
     }
-    // TODO: fix function param "reassignment"
-    seen.add( value );
-    return asset;
+    newSeen.add( value );
+    return true;
   } );
-  return uniqAssets;
+  return { uniqAssets, newSeen };
 };
 
 const fetchAlbums = async ( cameraRoll: Array<Object> ): Promise<Array<Object>> => {

--- a/utility/cameraRollHelpers.js
+++ b/utility/cameraRollHelpers.js
@@ -34,12 +34,11 @@ const fetchGalleryPhotos = async ( album: ?string, lastCursor: ?string ): Promis
 
 const checkForUniquePhotos = ( seen: Set<Object>, assets: Array<Object> ): { assets: Array<Object>, newSeen: Set<Object> } => {
   // from cameraroll example: https://github.com/react-native-cameraroll/react-native-cameraroll/blob/7fa9b7c062c166cd94e62b4ab5d1f7b5f663c9a0/example/js/CameraRollView.js#L177
-  
-  // seen state can't be mutated locally, instead it's returned and 
+  // seen state can't be mutated locally, instead it's returned and
   // used by the parent component to update state
   const newSeen = new Set( seen );
 
-  const uniqAssets = assets.filter( asset => {
+  const uniqAssets = assets.filter( ( asset ) => {
     const value = asset.node.image.uri;
     if ( newSeen.has( value ) ) {
       return false;

--- a/utility/cameraRollHelpers.js
+++ b/utility/cameraRollHelpers.js
@@ -35,7 +35,7 @@ const fetchGalleryPhotos = async ( album: ?string, lastCursor: ?string ): Promis
 const checkForUniquePhotos = (
   seen: Set<Object>,
   assets: Array<Object>
-): { uniqAssets: Array<Object>, newSeen: Set<Object> } => {
+): { newSeen: Set<Object>, uniqAssets: Array<Object> } => {
   // from cameraroll example: https://github.com/react-native-cameraroll/react-native-cameraroll/blob/7fa9b7c062c166cd94e62b4ab5d1f7b5f663c9a0/example/js/CameraRollView.js#L177
   // seen state can't be mutated locally, instead it's returned and
   // used by the parent component to update state

--- a/utility/cameraRollHelpers.js
+++ b/utility/cameraRollHelpers.js
@@ -32,7 +32,10 @@ const fetchGalleryPhotos = async ( album: ?string, lastCursor: ?string ): Promis
   return photos;
 };
 
-const checkForUniquePhotos = ( seen: Set<Object>, assets: Array<Object> ): { assets: Array<Object>, newSeen: Set<Object> } => {
+const checkForUniquePhotos = (
+  seen: Set<Object>,
+  assets: Array<Object>
+): { uniqAssets: Array<Object>, newSeen: Set<Object> } => {
   // from cameraroll example: https://github.com/react-native-cameraroll/react-native-cameraroll/blob/7fa9b7c062c166cd94e62b4ab5d1f7b5f663c9a0/example/js/CameraRollView.js#L177
   // seen state can't be mutated locally, instead it's returned and
   // used by the parent component to update state

--- a/utility/cameraRollHelpers.ts
+++ b/utility/cameraRollHelpers.ts
@@ -1,12 +1,9 @@
-// @flow
-
 import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import type {
-  GetPhotosParams,
-  PhotoIdentifiersPage
+  GetPhotosParams
 } from "@react-native-camera-roll/camera-roll";
 
-const setGalleryFetchOptions = ( album: ?string, lastCursor: ?string ) => {
+const setGalleryFetchOptions = ( album: string | null, lastCursor: string | null ) => {
   const options: GetPhotosParams = {
     first: 28,
     assetType: "Photos",
@@ -25,17 +22,25 @@ const setGalleryFetchOptions = ( album: ?string, lastCursor: ?string ) => {
   return options;
 };
 
-const fetchGalleryPhotos = async ( album: ?string, lastCursor: ?string ): Promise<PhotoIdentifiersPage> => {
+const fetchGalleryPhotos = async ( album: string | null, lastCursor: string | null ) => {
   const options = setGalleryFetchOptions( album, lastCursor );
 
   const photos = await CameraRoll.getPhotos( options );
   return photos;
 };
 
+interface Asset {
+  node: {
+    image: {
+      uri: string
+    }
+  }
+}
+
 const checkForUniquePhotos = (
-  seen: Set<Object>,
-  assets: Array<Object>
-): { newSeen: Set<Object>, uniqAssets: Array<Object> } => {
+  seen: Set<string>,
+  assets: Asset[]
+): { newSeen: Set<string>, uniqAssets: Asset[] } => {
   // from cameraroll example: https://github.com/react-native-cameraroll/react-native-cameraroll/blob/7fa9b7c062c166cd94e62b4ab5d1f7b5f663c9a0/example/js/CameraRollView.js#L177
   // seen state can't be mutated locally, instead it's returned and
   // used by the parent component to update state
@@ -52,7 +57,12 @@ const checkForUniquePhotos = (
   return { uniqAssets, newSeen };
 };
 
-const fetchAlbums = async ( cameraRoll: Array<Object> ): Promise<Array<Object>> => {
+export interface CondensedAlbum {
+  label: string,
+  value: string
+}
+
+const fetchAlbums = async ( cameraRoll: CondensedAlbum[] ) => {
   try {
     const names = cameraRoll;
     const albums = await CameraRoll.getAlbums( { assetType: "Photos" } );


### PR DESCRIPTION
### This issue has been bothering me for years and it took me a very long time to find the time to debug it with Xcode on my own local device.

1. load Seek
2. tap the camera icon
3. tap the "PHOTOS" tab at the bottom right
4. a new PHOTO LIBRARY page shows a spinning wheel which eventually resolves to a blank page of a slightly different color
5. if tap the "PHOTO LIBRARY" title and switch to any other album, photos eventually do load and get populated in the gallery, and this also works switching back to "PHOTO LIBRARY" (the default), hinting that this is a state bug.

Here's a video demonstration with the latest iOS release (2.16.3): 

https://github.com/user-attachments/assets/d418956c-b3a4-4543-b0aa-dcb85711ae41

It seems like @jtklein was at least aware of it based on this comment from last year in the [cameraRollHelpers checkForUniquePhotos helper function][1].

Mutating the `seen` state within the body of a helper function is not a good idea because this state mutation is invisible to React.

Having `checkForUniquePhotos()` return a tuple with both the `uniqAssets` array and the `newSeen` set allows us to call the `dispatch` method from `useReducer` to set the state of `seen` to the new state we get from `newSeen`.

# Fix

Here's what the fixed behavior in a local build: 

https://github.com/user-attachments/assets/ad6ec126-76db-427b-9c65-2a6046918710

Locally I also updated the @react-native-camera-roll/camera-roll dependency to the more recent 7.1.0 version which supports Smart Albums so let me know if you'd be interested to handle that.

[1]: https://github.com/olivierlacan/SeekReactNative/commit/1fd9e1508353504a2437dc2fca028093f5060394