### PR TITLE
Fix app state change resetting language

### DIFF
--- a/components/Providers/LanguageProvider.tsx
+++ b/components/Providers/LanguageProvider.tsx
@@ -18,6 +18,12 @@ const LanguageProvider = ( { children }: LanguageProviderProps ) => {
   const getLanguagePreference = async ( ) => setLanguage( await getLanguage( ) );
   const toggleLanguagePreference = ( ) => getLanguagePreference( );
 
+  const handleAppStateChange = React.useCallback( () => {
+    if ( preferredLanguage === "device" ) {
+      handleLocalizationChange();
+    }
+  }, [preferredLanguage] );
+
   React.useEffect( ( ) => {
     // wait until check for stored language is completed
     if ( !preferredLanguage ) { return; }
@@ -26,10 +32,10 @@ const LanguageProvider = ( { children }: LanguageProviderProps ) => {
 
   React.useEffect( ( ) => {
     getLanguagePreference( );
-    AppState.addEventListener( "change", handleLocalizationChange );
+    const listener = AppState.addEventListener( "change", handleAppStateChange );
 
-    return ( ) => AppState.removeEventListener( "change", handleLocalizationChange );
-  }, [] );
+		return () => listener.remove();
+  }, [handleAppStateChange] );
 
   const value = {
     toggleLanguagePreference,


### PR DESCRIPTION

Fixes #642

The issue was caused by every app state change (app moving to background/foreground) calling [`handleLocalizationChange`](https://github.com/inaturalist/SeekReactNative/blob/c80674ca6cb5860b341b5732e148663259ab1a1f/utility/languageHelpers.ts#L56), which sets the current language to the current device locale — regardless of the user's preference set in Settings. 

#### Changes proposed

- Only trigger the locale check when the user preference is the device language
- Fix incorrect removeEventListener call

Tested on iOS. I could reproduce the original issue with just leaving the app, launching something else then coming back, no need to wait for hours or any extra hoops.
