### PR TITLE
Update react-native-maps to 1.20.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,9 @@ buildscript {
         kotlinVersion = "2.0.21"
         // This specifies which tensorflow-lite version to use for our vision-plugin.
         tensorflowVersion = "2.17.0"
+        // RN-maps uses this version of play-services-location, but RN-geolocation-service
+        // uses 17.0.0 but is overridable like so
+        playServicesLocationVersion = "21.0.1"
     }
     repositories {
         google()

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1287,7 +1287,7 @@ PODS:
     - React-Core
   - react-native-mail (6.1.1):
     - React-Core
-  - react-native-maps (1.7.1):
+  - react-native-maps (1.20.1):
     - React-Core
   - react-native-netinfo (11.4.1):
     - React-Core
@@ -2251,7 +2251,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: 197ec356b2e16526610b3471c73ca6c884905a8f
   react-native-image-resizer: 24c5d06fae2176dc0caed4b6396e02befb44064a
   react-native-mail: 6e83813066984b26403d3fdfe79ac7bb31857e3c
-  react-native-maps: 38394e3f4258d7fe8f1241c2624b91acf35e2dd5
+  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-pager-view: 11662c698c8f11d39e05891316d2a144fa00adc4
   react-native-render-html: fc0eadab8b59ec87f34ea2355232a89b6c70364d

--- a/ios/Seek.xcodeproj/project.pbxproj
+++ b/ios/Seek.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-cameraroll/RNCameraRollPrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-maps/ReactNativeMapsPrivacy.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -467,6 +468,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCameraRollPrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReactNativeMapsPrivacy.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "react-native-localize": "^3.5.2",
         "react-native-logs": "^5.0.1",
         "react-native-mail": "^6.1.1",
-        "react-native-maps": "^1.7.1",
+        "react-native-maps": "1.20.1",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-modal-datetime-picker": "^18.0.0",
         "react-native-pager-view": "^6.8.1",
@@ -4050,9 +4050,10 @@
       "dev": true
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -12516,11 +12517,15 @@
       "integrity": "sha512-pTs180wwyh7hN/iyTC9SfOX579U4YhDlHOLxi47IGvhPJENqO/QFdBq+wWKxyhNqdQuVSy+LoeIxLreWnIeYmg=="
     },
     "node_modules/react-native-maps": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.7.1.tgz",
-      "integrity": "sha512-CHVLzL+Q2jiUGgbt4/vosxVI1SukWyaLGjD62VLgR/wZpnH4Umi9ql1bmKDPWcfj2C1QZwMU0Yc7rXTbvZUIiw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/geojson": "^7946.0.10"
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
         "react": ">= 17.0.1",
@@ -17497,9 +17502,9 @@
       "dev": true
     },
     "@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
     },
     "@types/graceful-fs": {
       "version": "4.1.9",
@@ -23625,11 +23630,11 @@
       "integrity": "sha512-pTs180wwyh7hN/iyTC9SfOX579U4YhDlHOLxi47IGvhPJENqO/QFdBq+wWKxyhNqdQuVSy+LoeIxLreWnIeYmg=="
     },
     "react-native-maps": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.7.1.tgz",
-      "integrity": "sha512-CHVLzL+Q2jiUGgbt4/vosxVI1SukWyaLGjD62VLgR/wZpnH4Umi9ql1bmKDPWcfj2C1QZwMU0Yc7rXTbvZUIiw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
       "requires": {
-        "@types/geojson": "^7946.0.10"
+        "@types/geojson": "^7946.0.13"
       }
     },
     "react-native-modal": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-localize": "^3.5.2",
     "react-native-logs": "^5.0.1",
     "react-native-mail": "^6.1.1",
-    "react-native-maps": "1.13.2",
+    "react-native-maps": "1.20.1",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",
     "react-native-pager-view": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-localize": "^3.5.2",
     "react-native-logs": "^5.0.1",
     "react-native-mail": "^6.1.1",
-    "react-native-maps": "^1.7.1",
+    "react-native-maps": "1.13.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",
     "react-native-pager-view": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-localize": "^3.5.2",
     "react-native-logs": "^5.0.1",
     "react-native-mail": "^6.1.1",
-    "react-native-maps": "1.13.0",
+    "react-native-maps": "1.13.2",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",
     "react-native-pager-view": "^6.8.1",


### PR DESCRIPTION
Compiled and tested in Debug and Release mode on both platforms.

According to the changelog, this is the last version that supports RN with the old architecture.

Half of MOB-904