### PR TITLE
Update react-native-fs version number in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "react-native-device-info": "^14.0.4",
         "react-native-exception-handler": "^2.10.10",
         "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#bb13be9d3ae187e770e26132b9ddf8d3a622478d",
-        "react-native-fs": "^2.18.0",
+        "react-native-fs": "^2.20.0",
         "react-native-geocoder": "git+https://github.com/a-voityuk/react-native-geocoder.git",
         "react-native-geolocation-service": "^5.3.1",
         "react-native-gesture-handler": "2.22.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-native-device-info": "^14.0.4",
     "react-native-exception-handler": "^2.10.10",
     "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#bb13be9d3ae187e770e26132b9ddf8d3a622478d",
-    "react-native-fs": "^2.18.0",
+    "react-native-fs": "^2.20.0",
     "react-native-geocoder": "git+https://github.com/a-voityuk/react-native-geocoder.git",
     "react-native-geolocation-service": "^5.3.1",
     "react-native-gesture-handler": "2.22.1",


### PR DESCRIPTION
Not actually updating anything, as we already use 2.20.0.

Closes MOB-905